### PR TITLE
Extends API to return rule info and matched rule chain

### DIFF
--- a/lib/node-rules.js
+++ b/lib/node-rules.js
@@ -50,13 +50,17 @@
         var session = _.clone(fact);
         var lastSession = _.clone(fact);
         var _rules = this.activeRules;
+        var matchPath = [];
         var ignoreFactChanges = this.ignoreFactChanges;
         (function FnRuleLoop(x) {
             var API = {
+                "rule": function() { return _rules[x]; },
                 "when": function(outcome) {
                     if (outcome) {
                         var _consequence = _rules[x].consequence;
+                        _consequence.ruleRef = _rules[x].id || _rules[x].name || 'index_'+x;
                         process.nextTick(function() {
+                            matchPath.push(_consequence.ruleRef);
                             _consequence.call(session, API);
                         });
                     } else {
@@ -90,6 +94,7 @@
                 _rule.call(session, API);
             } else {
                 process.nextTick(function() {
+                    session.matchPath = matchPath;
                     return callback(session);
                 });
             }

--- a/test/index.js
+++ b/test/index.js
@@ -168,6 +168,85 @@ describe("Rules", function() {
                 expect(result.result).to.eql("Custom Result");
             });
         });
+        it("should provide access to rule definition properties via rule()", function() {
+            var rule = {
+                "name": "sample rule name",
+                "id": "xyzzy",
+                "condition": function(R) {
+                    R.when(this && (this.input === true));
+                },
+                "consequence": function(R) {
+                    this.result = true;
+                    this.ruleName = R.rule().name;
+                    this.ruleID = R.rule().id;
+                    R.stop();
+                }
+            };
+            var R = new RuleEngine(rule);
+            R.execute({
+                "input": true
+            }, function(result) {
+                expect(result.ruleName).to.eql(rule.name);
+                expect(result.ruleID).to.eql(rule.id);
+            });
+        });
+        it("should include the matched rule path", function() {
+            var rules = [
+                {
+                    "name": "rule A",
+                    "condition": function(R) {
+                        R.when(this && (this.x === true));
+                    },
+                    "consequence": function(R) {
+                        R.next();
+                    }
+                },
+                {
+                    "name": "rule B",
+                    "condition": function(R) {
+                        R.when(this && (this.y === true));
+                    },
+                    "consequence": function(R) {
+                        R.next();
+                    }
+                },
+                {
+                    "id": "rule C",
+                    "condition": function(R) {
+                        R.when(this && (this.x === true && this.y === false));
+                    },
+                    "consequence": function(R) {
+                        R.next();
+                    }
+                },
+                {
+                    "id": "rule D",
+                    "condition": function(R) {
+                        R.when(this && (this.x === false && this.y === false));
+                    },
+                    "consequence": function(R) {
+                        R.next();
+                    }
+                },
+                {
+                    "condition": function(R) {
+                        R.when(this && (this.x === true && this.y === false));
+                    },
+                    "consequence": function(R) {
+                        R.next();
+                    }
+                }
+            ];
+            var lastMatch = 'index_' + ((rules.length)-1).toString();
+            var R = new RuleEngine(rules);
+            R.execute({
+                "x": true,
+                "y": false
+            }, function(result) {
+                expect(result.matchPath).to.eql([rules[0].name, rules[2].id, lastMatch]);
+            });
+        });
+        
     });
     describe(".findRules()", function() {
         var rules = [{


### PR DESCRIPTION
This PR adds two simple features.  

The first feature is lifted from the un-merged suggestions by @escape-llc at https://github.com/mithunsatheesh/node-rules/issues/39.  Namely, adding a rule() method to the API inside .execute(), so that rule information can be accessed inside the consequence, like so:
```
"consequence": function(R) {
    this.result = true;
    this.ruleName = R.rule().name;
    this.ruleID = R.rule().id;
    R.stop();
}
```

The second feature is something I needed for my implementation, namely the list of matched rules in matched order.   In my case, the rules are defined by others, and when they get unexpected/undesirable results through the rule engine, this helps them understand how the rules got processed.  The list of matched rules is an array named .matchPath, attached to the callback results from .execute().  The array values are the matched rule's .id property, or .name property, or active rule index position, in that order of preference.

I included some simple tests and appended them to the existing describe block for .execute()

* lib/node-rules.js:
   - adds rule() to .execute API to access rule().name, rule().id, etc
   - adds var matchPath array to hold the chain of matched rule references (by id, or by name, or by active rule index)
   - decorates returned session in final callback with .matchPath

* test/index.js:
   - adds test to .execute block: "should provide access to rule definitions via rule()"
   - adds test to .execute block: "should include the matched rule path"

