### PR TITLE
added support for arrow-functions

### DIFF
--- a/lib/node-rules.js
+++ b/lib/node-rules.js
@@ -61,7 +61,7 @@
                         _consequence.ruleRef = _rules[x].id || _rules[x].name || 'index_'+x;
                         process.nextTick(function() {
                             matchPath.push(_consequence.ruleRef);
-                            _consequence.call(session, API);
+                            _consequence.call(session, API, session);
                         });
                     } else {
                         process.nextTick(function() {
@@ -91,7 +91,7 @@
             };
             if (x < _rules.length && complete === false) {
                 var _rule = _rules[x].condition;
-                _rule.call(session, API);
+                _rule.call(session, API, session);
             } else {
                 process.nextTick(function() {
                     session.matchPath = matchPath;

--- a/test/index.js
+++ b/test/index.js
@@ -246,6 +246,24 @@ describe("Rules", function() {
                 expect(result.matchPath).to.eql([rules[0].name, rules[2].id, lastMatch]);
             });
         });
+
+        it("should support fact as optional second parameter for es6 compatibility", function() {
+            var rule = {
+                "condition": function(R, fact) {
+                    R.when(fact && (fact.transactionTotal < 500));
+                },
+                "consequence": function(R, fact) {
+                    fact.result = false;
+                    R.stop();
+                }
+            };
+            var R = new RuleEngine(rule);
+            R.execute({
+                "transactionTotal": 200
+            }, function(result) {
+                expect(result.result).to.eql(false);
+            });
+        });
         
     });
     describe(".findRules()", function() {


### PR DESCRIPTION
Related to issue https://github.com/mithunsatheesh/node-rules/issues/48
The old syntax with "this" is still supported but now you're able to use arrow functions.
