### PR TITLE
explicit export types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,8 @@ import isEqual from "lodash.isequal";
 
 import { Rule, Options, Fact, API } from "./types";
 
+export {Rule, Options, Fact, API}
+
 export class RuleEngine {
   public rules: Rule[] = [];
   public activeRules: Rule[] = [];


### PR DESCRIPTION
Explicit export of api types to allow for a more flexible use of rule definitions and this library.
Currently, only RuleEngine is exported in the dist/index.d.ts but it would be nice to have the other types exported as well. 

For instance, to be able to define rules as re-useable functions and defining rules as separate variable.

```
const rules: Rule[] = [
   myReuseableFunction(api, fact)
  ,{
    name: 'ageOfDog',
    priority: 1,
    condition: (api: API, fact: Fact) => {
      api.when(fact.age > 5)
    },
    consequence: (R: API, fact: Fact) => {
      fact.result = false
      fact.reason = 'The dog is older than 5 years.'
      R.stop()
    }
  }
]

eng.register(rules)
```